### PR TITLE
fix: Account balancer, negative send bug

### DIFF
--- a/app/backend/speedtest_api/management/commands/balance_accounts.py
+++ b/app/backend/speedtest_api/management/commands/balance_accounts.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
             if values[upper] == mean:
                 del values[upper]
                 del accounts[upper]
-                upper = upper - 1
+                continue
             
             found_upper = accounts[upper].POW is not None
         


### PR DESCRIPTION
fix #91: prevent upper = lower account selection when the upper account is already balanced