### PR TITLE
#135 - Email checking is not done fix

### DIFF
--- a/app/frontend/src/components/BuildAd.jsx
+++ b/app/frontend/src/components/BuildAd.jsx
@@ -320,7 +320,7 @@ class BuildAd extends Component {
                       <div className='form-group'>
                             <label htmlFor='email'><b>E-mail Address</b></label>
                             <input
-                                type='text'
+                                type='email'
                                 className='form-control'
                                 name='email'
                                 value={email}


### PR DESCRIPTION
Presently, when a user navigates to the [BuildAd](https://nanospeed.live/BuildAd) page, they are presented with a form that collects information including and email. Per issue [135](https://github.com/silverstar194/Nano-SpeedTest/issues/135), the input of the input field named `email` is not validated in any way. To solve this issue, the input field in question had the `type` changed from `text` to `email`.

More information about the `email` type can be found [here](https://www.w3schools.com/tags/att_input_type_email.asp).

![NanoSpeedTest-135](https://user-images.githubusercontent.com/39778093/66090434-9b703300-e540-11e9-95c3-7d1127357457.png)
